### PR TITLE
Update Google Groups link and email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the documentation for the Opencast-Moodle Usergroup.
 
 For the communication within the community there are two mediums:
 
-* [Mailinglist on Google Groups](https://groups.google.com/a/opencast.org/forum/#!forum/moodle-opencast): moodle-opencast@opencast.org
+* [Mailinglist on Google Groups](https://groups.google.com/a/opencast.org/g/lms): lms@opencast.org
 * Telegram: To join ask for a link on the mailinglist or use the Matrix bridge: #opencast-moodle-usergroup:matrix.org
 
 ## Meetings


### PR DESCRIPTION
Since the email address for the google group was changed to lms@opencast.org the old link isn't working anymore.

See https://groups.google.com/a/opencast.org/g/lms/c/H3j6bvuh7z4